### PR TITLE
lock to mysql >= 1.3.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe "database::ebs_volume", "Sets up an EBS volume in EC2 for the database"
 recipe "database::master", "Creates application specific user and database"
 recipe "database::snapshot", "Locks tables and freezes XFS filesystem for replication, assumes EC2 + EBS"
 
-depends "mysql", ">= 1.2.0"
+depends "mysql", ">= 1.3.0"
 depends "postgresql"
 depends "aws"
 depends "xfs"


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1561

Recently we fixed some bugs in COOK-1441 for MySQL and the Database cookbook.

These changes have been released in version mysql 1.3.0 and database 1.3.2.

Database 1.3.2 requires MySQL >= 1.2.0 but will not actually work with 1.2.0. This constraint needs to be bumped to >= 1.3.0.
