### PR TITLE
[COOK-2047] Filter passwords from log

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -56,9 +56,17 @@ class Chef
 
         def action_grant
           begin
-            grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON `#{@new_resource.database_name || "*"}`.`#{@new_resource.table || "*"}` TO `#{@new_resource.username}'@'#{@new_resource.host}` IDENTIFIED BY '#{@new_resource.password}'"
-            Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}]")
-            db.query(grant_statement)
+            # does password look like MySQL hex digest?
+            # (begins with *, followed by 40 hexadecimal characters)
+            if (/(\A\*[0-9A-F]{40}\z)/i).match(@new_resource.password) then
+              password = filtered = "PASSWORD '#{$1}'"
+            else
+              password = "'#{@new_resource.password}'"
+              filtered = '[FILTERED]'
+            end
+            grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON `#{@new_resource.database_name || "*"}`.`#{@new_resource.table || "*"}` TO `#{@new_resource.username}`@`#{@new_resource.host}` IDENTIFIED BY "
+            Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}#{filtered}]")
+            db.query(grant_statement + password)
             @new_resource.updated_by_last_action(true)
           ensure
             close


### PR DESCRIPTION
- Add check for MySQL hex digests; pass these to the log while filtering
  plaintext passwords
- Fix bug in `user`@`host` substring (replace single quotes around @
  with backticks)
