### PR TITLE
[COOK-2060] Fix remove backticks when table is nil

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -64,7 +64,7 @@ class Chef
               password = "'#{@new_resource.password}'"
               filtered = '[FILTERED]'
             end
-            grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON `#{@new_resource.database_name || "*"}`.`#{@new_resource.table || "*"}` TO `#{@new_resource.username}`@`#{@new_resource.host}` IDENTIFIED BY "
+            grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON `#{@new_resource.database_name || '*'}`.#{@new_resource.table ? "`#{@new_resource.table}`" : '*'} TO `#{@new_resource.username}`@`#{@new_resource.host}` IDENTIFIED BY "
             Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}#{filtered}]")
             db.query(grant_statement + password)
             @new_resource.updated_by_last_action(true)


### PR DESCRIPTION
- remove backticks from table name when table attribute is nil
- GRANT SELECT ON `*`.`*` TO `some_user`@`%` IDENTIFIED BY 'secret';
  causes MySQL error
- GRANT SELECT ON `*`.\* TO `some_user`@`%` IDENTIFIED BY 'secret'; succeeds
