### PR TITLE
Fix a typo in readme postgres_database -> postgresql_database

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ depending on your RDBMS: `mysql_database`, `postgresql_database` or
     end
 
     # vacuum a postgres database
-    postgres_database "vacuum databases" do
+    postgresql_database "vacuum databases" do
       connection postgresql_connection_info
       database_table "template1"
       sql "VACUUM FULL VERBOSE ANALYZE"


### PR DESCRIPTION
This fixes a typo on the docs.
