### PR TITLE
Perform a case insensitive DB name comparison for SQL Server

### DIFF
--- a/libraries/provider_database_sql_server.rb
+++ b/libraries/provider_database_sql_server.rb
@@ -77,7 +77,7 @@ class Chef
           begin
             result = db.execute("SELECT name FROM sys.databases")
             result.each do |row|
-              if row['name'] == @new_resource.database_name
+              if row['name'].casecmp(@new_resource.database_name) == 0
                 exists = true
                 break
               end


### PR DESCRIPTION
SQL Server is generally case insensitive, however the database name comparison here is case sensitive.

This patch changes the database name comparison to be case insensitive in order to match the behavior expected by SQL Server users.
