### PR TITLE
Init TinyTds connection with the database name & sane timeout

### DIFF
--- a/libraries/provider_database_sql_server.rb
+++ b/libraries/provider_database_sql_server.rb
@@ -91,14 +91,14 @@ class Chef
 
         def db
           @db ||= begin
-            ::TinyTds::Client.new(
-              :host => @new_resource.connection[:host],
+            opts = { :host => @new_resource.connection[:host],
               :username => @new_resource.connection[:username],
               :password => @new_resource.connection[:password],
               :port => @new_resource.connection[:port] || 1433,
-              :database => @new_resource.database_name,
-              :timeout => 120
-            )
+              :timeout => 120 }
+            opts[:database] = @new_resource.database_name if action == :query
+            
+            ::TinyTds::Client.new(opts)
           end
         end
 


### PR DESCRIPTION
The specified `database_name` value should be passed down into TinyTds when creating the SQL Server connection.

Otherwise you'll run the script against the default db, which is likely not what you'll want, or you'll have to specify the db in each script, which is an unnecessary extra step and easy to forget.

Also, let's bump the query timeout from the default 5 seconds to 120 seconds.
