### PR TITLE
Fixed issue with multi-statement SQL Server queries

### DIFF
--- a/libraries/provider_database_sql_server.rb
+++ b/libraries/provider_database_sql_server.rb
@@ -63,7 +63,7 @@ class Chef
             begin
               #db.select_db(@new_resource.database_name) if @new_resource.database_name
               Chef::Log.debug("#{@new_resource}: Performing query [#{new_resource.sql_query}]")
-              db.execute(@new_resource.sql_query).do
+              db.execute(@new_resource.sql_query).each
               @new_resource.updated_by_last_action(true)
             ensure
               close


### PR DESCRIPTION
When issuing multi-statement sql queries, TinyTds requires iterating through the entire result set via the `each` method.

Using the `do` method results in undefined behavior (in my case only the first ~230 insert statements succeeded and then TinyTds returned without an error).

This patch simply changes the `db.execute(@new_resource.sql_query).do` line to `db.execute(@new_resource.sql_query).each`.

See the `TinyTds::Result Usage` section @ https://github.com/rails-sqlserver/tiny_tds for further details.
