### PR TITLE
Use peer-authorized postgresql connections where applicable

### DIFF
--- a/libraries/provider_database_postgresql_user.rb
+++ b/libraries/provider_database_postgresql_user.rb
@@ -42,6 +42,8 @@ class Chef
               close
             end
           end
+        rescue Chef::Provider::Database::Postgresql::RoleNotFoundError
+          create_with_command
         end
 
         def action_drop
@@ -75,6 +77,21 @@ class Chef
             close
           end
           exists
+        end
+
+        def create_with_command
+          Chef::Application.fatal! "setting password not supported when creating user with command" if @new_resource.password
+
+          username = @new_resource.username
+          command = "!(createuser -s \"#{username}\" 2>&1 | grep -v 'already exists')"
+
+          Chef::Log.info("#{@new_resource}: creating user with command [#{command}]")
+          bash "create postgres user #{username}" do
+            user 'postgres'
+            code command
+          end
+
+          @new_resource.updated_by_last_action(true)
         end
 
       end

--- a/libraries/resource_postgresql_database.rb
+++ b/libraries/resource_postgresql_database.rb
@@ -30,6 +30,14 @@ class Chef
         @provider = Chef::Provider::Database::Postgresql
       end
 
+      def connection(arg=nil)
+        set_or_return(
+          :connection,
+          arg,
+          :required => false
+        )
+      end
+
     end
   end
 end

--- a/libraries/resource_postgresql_database_user.rb
+++ b/libraries/resource_postgresql_database_user.rb
@@ -30,6 +30,23 @@ class Chef
         @provider = Chef::Provider::Database::PostgresqlUser
       end
 
+      def connection(arg=nil)
+        set_or_return(
+          :connection,
+          arg,
+          :required => false
+        )
+      end
+
+      def password(arg=nil)
+        set_or_return(
+          :password,
+          arg,
+          :kind_of => String,
+          :required => false
+        )
+      end
+
     end
   end
 end


### PR DESCRIPTION
Using password and tcp to connect to a postgres database on a local machine is in the best case a bit inefficient and in the worst case very insecure. This patch tries to use peer authentication where feasible.
