### PR TITLE
Remove hard "template1" in pg

### DIFF
--- a/libraries/provider_database_postgresql.rb
+++ b/libraries/provider_database_postgresql.rb
@@ -49,7 +49,7 @@ class Chef
               create_sql += " CONNECTION LIMIT = #{new_resource.connection_limit}" if new_resource.connection_limit
               create_sql += " OWNER = \"#{new_resource.owner}\"" if new_resource.owner
               Chef::Log.debug("#{@new_resource}: Performing query [#{create_sql}]")
-              db('template1').query(create_sql)
+              db(@new_resource.connection_database).query(create_sql)
               @new_resource.updated_by_last_action(true)
             ensure
               close
@@ -61,7 +61,7 @@ class Chef
           if exists?
             begin
               Chef::Log.debug("#{@new_resource}: Dropping database #{new_resource.database_name}")
-              db('template1').query("DROP DATABASE \"#{new_resource.database_name}\"")
+              db(@new_resource.connection_database).query("DROP DATABASE \"#{new_resource.database_name}\"")
               @new_resource.updated_by_last_action(true)
             ensure
               close
@@ -87,7 +87,7 @@ class Chef
         def exists?
           begin
             Chef::Log.debug("#{@new_resource}: checking if database #{@new_resource.database_name} exists")
-            ret = db('template1').query("SELECT * FROM pg_database where datname = '#{@new_resource.database_name}'").num_tuples != 0
+            ret = db(@new_resource.connection_database).query("SELECT * FROM pg_database where datname = '#{@new_resource.database_name}'").num_tuples != 0
             ret ? Chef::Log.debug("#{@new_resource}: database #{@new_resource.database_name} exists") :
                   Chef::Log.debug("#{@new_resource}: database #{@new_resource.database_name} does not exist")
           ensure

--- a/libraries/provider_database_postgresql_user.rb
+++ b/libraries/provider_database_postgresql_user.rb
@@ -39,7 +39,7 @@ class Chef
             begin
               statement = "CREATE USER \"#{@new_resource.username}\""
               statement += " WITH PASSWORD '#{@new_resource.password}'" if @new_resource.password
-              db('template1').query(statement)
+              db(@new_resource.connection_database).query(statement)
               @new_resource.updated_by_last_action(true)
             ensure
               close
@@ -50,7 +50,7 @@ class Chef
         def action_drop
           if exists?
             begin
-              db('template1').query("DROP USER \"#{@new_resource.username}\"")
+              db(@new_resource.connection_database).query("DROP USER \"#{@new_resource.username}\"")
               @new_resource.updated_by_last_action(true)
             ensure
               close
@@ -84,7 +84,7 @@ class Chef
         private
         def exists?
           begin
-            exists = db('template1').query("SELECT * FROM pg_user WHERE usename='#{@new_resource.username}'").num_tuples != 0
+            exists = db(@new_resource.connection_database).query("SELECT * FROM pg_user WHERE usename='#{@new_resource.username}'").num_tuples != 0
           ensure
             close
           end

--- a/libraries/resource_postgresql_database.rb
+++ b/libraries/resource_postgresql_database.rb
@@ -26,7 +26,17 @@ class Chef
       def initialize(name, run_context = nil)
         super
         @resource_name = :postgresql_database
+        @connection_database = :template1
         @provider = Chef::Provider::Database::Postgresql
+      end
+
+      def connection_database(arg = nil)
+        set_or_return(
+          :connection_database,
+          arg,
+          :kind_of => String,
+          :default => 'template1'
+        )
       end
     end
   end

--- a/libraries/resource_postgresql_database_user.rb
+++ b/libraries/resource_postgresql_database_user.rb
@@ -39,6 +39,15 @@ class Chef
           :kind_of => String
         )
       end
+
+      def connection_database(arg = nil)
+        set_or_return(
+          :connection_database,
+          arg,
+          :kind_of => String,
+          :default => 'template1'
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
When you use a pooler (like pgpool) with this cookbook you can't create database with template1 as template because your connection isn't close. It will be better if we can configure the database connection.
