### PR TITLE
Do not print MySQL user passwords on info level

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -373,7 +373,7 @@ class Chef
         end
 
         def redact_password(query, password)
-          if password.nil? or password == ''
+          if password.nil? || password == ''
             query
           else
             query.gsub(password, 'REDACTED')


### PR DESCRIPTION
### Description

Since converge_by statements already produce output, change two
statements intended for debugging to debug level from info. In
addition, redact the MySQL user password from the output in the
grant statement that is printed.

### Issues Resolved

MySQL passwords being dumped into Chef logs